### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: issue-notifier
-        uses: timheuer/issue-notifier@v1.0.2
+        uses: timheuer/issue-notifier@49a9c6d9bbb81b9609a53f1e28f9aab8657be7b5 # v1.0.2
         env:
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Install dependencies
         run: |
           # Get Nix


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v2` -> `actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0`
  - Version: v2.7.0 | Latest: v6.0.2 | Release age: 89d
  - Commit: https://github.com/actions/checkout/commit/ee0669bd1cc54295c223e0bb666b733df41de1c5

- `timheuer/issue-notifier@v1.0.2` -> `timheuer/issue-notifier@49a9c6d9bbb81b9609a53f1e28f9aab8657be7b5 # v1.0.2`
  - Version: v1.0.2 | Latest: v1 | Release age: 2357d
  - Commit: https://github.com/timheuer/issue-notifier/commit/49a9c6d9bbb81b9609a53f1e28f9aab8657be7b5


### Files modified

- `.github/workflows/issue-notifier.yml`
- `.github/workflows/main.yml`